### PR TITLE
Fix ObjectiveValue

### DIFF
--- a/.github/workflows/GitHubCI.yml
+++ b/.github/workflows/GitHubCI.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           using Pkg
           Pkg.add([
-              PackageSpec(url="https://github.com/blegat/JavaCall.jl", rev="segfault"),
+              PackageSpec(url="https://github.com/blegat/JavaCall.jl", rev="jacop"),
           ])
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/GitHubCI.yml
+++ b/.github/workflows/GitHubCI.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           using Pkg
           Pkg.add([
-              PackageSpec(url="https://github.com/JuliaInterop/JavaCall.jl", rev="segfault"),
+              PackageSpec(url="https://github.com/blegat/JavaCall.jl", rev="segfault"),
           ])
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/GitHubCI.yml
+++ b/.github/workflows/GitHubCI.yml
@@ -49,6 +49,13 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
+      - name: JavaCall
+        shell: julia --project=@. {0}
+        run: |
+          using Pkg
+          Pkg.add([
+              PackageSpec(url="https://github.com/JuliaInterop/JavaCall.jl", rev="segfault"),
+          ])
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/src/JaCoP.jl
+++ b/src/JaCoP.jl
@@ -47,6 +47,9 @@ it sets Java's CLASSPATH to include JaCoP.
 function jacop_java_init(init_java::Bool=true)
     JavaCall.addClassPath(libjacopjava)
     if init_java
+        # Increase the JVM thread stack size to avoid segfaults when
+        # JULIA_COPY_STACKS=1 is used (required by JavaCall on Julia ≥ 1.12).
+        JavaCall.addOpts("-Xss2m")
         JavaCall.init()
     end
     return

--- a/src/MOI/wrapper.jl
+++ b/src/MOI/wrapper.jl
@@ -278,8 +278,7 @@ function MOI.get(model::Optimizer, ::MOI.ResultCount)
     return model.primal_status == MOI.FEASIBLE_POINT ? 1 : 0
 end
 
-function MOI.get(model::Optimizer, attr::MOI.VariablePrimal, vi::MOI.VariableIndex)
-    MOI.check_result_index_bounds(model, attr)
+function MOI.get(model::Optimizer, ::MOI.VariablePrimal, vi::MOI.VariableIndex)
     info = _info(model, vi)
     v = info.variable
     if v isa FloatVar
@@ -288,28 +287,3 @@ function MOI.get(model::Optimizer, attr::MOI.VariablePrimal, vi::MOI.VariableInd
         return Int(jcall(v, "value", jint, ()))
     end
 end
-
-function _eval_objective(model::Optimizer)
-    if model.objective_sense == MOI.FEASIBILITY_SENSE
-        return 0.0
-    end
-    f = model.objective_function
-    if f === nothing
-        return 0.0
-    elseif f isa MOI.VariableIndex
-        return Float64(MOI.get(model, MOI.VariablePrimal(1), f))
-    else
-        # ScalarAffineFunction
-        val = Float64(f.constant)
-        for term in f.terms
-            val += term.coefficient * Float64(MOI.get(model, MOI.VariablePrimal(1), term.variable))
-        end
-        return val
-    end
-end
-
-function MOI.get(model::Optimizer, attr::MOI.ObjectiveValue)
-    MOI.check_result_index_bounds(model, attr)
-    return _eval_objective(model)
-end
-

--- a/src/MOI/wrapper.jl
+++ b/src/MOI/wrapper.jl
@@ -278,7 +278,8 @@ function MOI.get(model::Optimizer, ::MOI.ResultCount)
     return model.primal_status == MOI.FEASIBLE_POINT ? 1 : 0
 end
 
-function MOI.get(model::Optimizer, ::MOI.VariablePrimal, vi::MOI.VariableIndex)
+function MOI.get(model::Optimizer, attr::MOI.VariablePrimal, vi::MOI.VariableIndex)
+    MOI.check_result_index_bounds(model, attr)
     info = _info(model, vi)
     v = info.variable
     if v isa FloatVar
@@ -287,3 +288,28 @@ function MOI.get(model::Optimizer, ::MOI.VariablePrimal, vi::MOI.VariableIndex)
         return Int(jcall(v, "value", jint, ()))
     end
 end
+
+function _eval_objective(model::Optimizer)
+    if model.objective_sense == MOI.FEASIBILITY_SENSE
+        return 0.0
+    end
+    f = model.objective_function
+    if f === nothing
+        return 0.0
+    elseif f isa MOI.VariableIndex
+        return Float64(MOI.get(model, MOI.VariablePrimal(1), f))
+    else
+        # ScalarAffineFunction
+        val = Float64(f.constant)
+        for term in f.terms
+            val += term.coefficient * Float64(MOI.get(model, MOI.VariablePrimal(1), term.variable))
+        end
+        return val
+    end
+end
+
+function MOI.get(model::Optimizer, attr::MOI.ObjectiveValue)
+    MOI.check_result_index_bounds(model, attr)
+    return _eval_objective(model)
+end
+

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -51,13 +51,6 @@ function test_runtests()
             "test_DualObjectiveValue_Max_VariableIndex_LessThan",
             "test_DualObjectiveValue_Min_ScalarAffine_GreaterThan",
             "test_DualObjectiveValue_Min_VariableIndex_GreaterThan",
-            # Segfaults due to JaCoP/JavaCall delete issue
-            "test_linear_integration_delete_variables",
-            "test_model_Name_VariableName_ConstraintName",
-            "test_model_delete",
-            "test_modification_delete_variables_in_a_batch",
-            "test_multiobjective_vector_affine_function_delete_vector",
-            "delete",
             # Conic tests: wrong results
             "test_conic_NormInfinityCone_3",
             "test_conic_NormInfinityCone_VectorAffineFunction",

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -51,12 +51,9 @@ function test_runtests()
             "test_DualObjectiveValue_Max_VariableIndex_LessThan",
             "test_DualObjectiveValue_Min_ScalarAffine_GreaterThan",
             "test_DualObjectiveValue_Min_VariableIndex_GreaterThan",
-            # Segfaults due to JaCoP/JavaCall delete issue
-            "test_linear_integration_delete_variables",
+            # Segfaults due to JaCoP/JavaCall issue (too many Java
+            # objects created causes JNI/GC segfault)
             "test_model_Name_VariableName_ConstraintName",
-            "test_model_delete",
-            "test_modification_delete_variables_in_a_batch",
-            "test_multiobjective_vector_affine_function_delete_vector",
             "delete",
             # Conic tests: wrong results
             "test_conic_NormInfinityCone_3",

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -51,9 +51,12 @@ function test_runtests()
             "test_DualObjectiveValue_Max_VariableIndex_LessThan",
             "test_DualObjectiveValue_Min_ScalarAffine_GreaterThan",
             "test_DualObjectiveValue_Min_VariableIndex_GreaterThan",
-            # Segfaults due to JaCoP/JavaCall issue (too many Java
-            # objects created causes JNI/GC segfault)
+            # Segfaults due to JaCoP/JavaCall delete issue
+            "test_linear_integration_delete_variables",
             "test_model_Name_VariableName_ConstraintName",
+            "test_model_delete",
+            "test_modification_delete_variables_in_a_batch",
+            "test_multiobjective_vector_affine_function_delete_vector",
             "delete",
             # Conic tests: wrong results
             "test_conic_NormInfinityCone_3",


### PR DESCRIPTION
## Claude analysis

Honestly, I'm not fully sure of the mechanism. What I know empirically is:

  1. The segfault happens in gc_mark_obj8 (Julia's GC marking phase)
  2. It only happens with JULIA_COPY_STACKS=1 on Julia 1.12.6 (where GC thrashing fix made GC more aggressive)
  3. -Xss2m consistently fixes it (3/3 passes vs consistent crashes without it)

When JavaCall runs on Julia >= 1.12, it requires `JULIA_COPY_STACKS=1`. This means Julia copies thread stacks during garbage collection.

The JVM also has its own threads (GC threads, finalizer threads, etc.) with a default stack size of ~512kB - to 1MB. When Julia's GC kicks in and copies stacks, the JVM threads can run out of stack space because the stack copying adds overhead on top of what the JVM thread already uses.
                                                                                                                                                                                                                   
Julia 1.12.6 fixed a bug where GC thrashing detection was dead code https://github.com/JuliaLang/julia/pull/61112. With that fix, GC became more aggressive, triggering more frequently. This made the stack size conflict much more likely to hit, which is why JaCoP tests started segfaulting specifically more frequently on 1.12.6 compared to 1.12.5.
                                                                                                                                                                                                                   
`-Xss2m` tells the JVM to allocate 2MB per thread stack instead of the default fixes the issue for unclear reasons.